### PR TITLE
Proxy cache URL fails match when part UrlEncoded

### DIFF
--- a/app/services/Proxy.js
+++ b/app/services/Proxy.js
@@ -60,7 +60,7 @@ Proxy.prototype = {
                 var response = JSON.parse(resp);
                 var responseArray = response.log.entries.reverse();
                 responseArray.forEach(function (entire) {
-                    if (entire.request.url == url) {
+                    if (entire.request.url == url || entire.request.url == decodeURIComponent(url)) {
                         foundEntire = entire;
                         result = true;
                     }
@@ -84,7 +84,7 @@ Proxy.prototype = {
                 var response = JSON.parse(resp);
                 var responseArray = response.log.entries.reverse();
                 responseArray.forEach(function (entire) {
-                    if (entire.request.url == url) {
+                    if (entire.request.url == url || entire.request.url == decodeURIComponent(url)) {
                         foundEntire = entire;
                         result = true;
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plus.garden",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "garden.js",
   "license": "MIT",
   "repository": "linkshare/plus.garden",


### PR DESCRIPTION
If I use browsermob-proxy to open url `http://example.com?href=http%3A%2F%2Fexample.com`
Then the URL that appears in the cache is actually `http://example.com?href=http://example.com` which is technically wrong as it contains characters that should remain encoded, and no longer matches our submitted URL. But as we can't fix that here, we're stuck trying to bodge the situation.
