### PR TITLE
Error handling for BrowserMob Proxy init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plus.garden",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "main": "garden.js",
   "license": "MIT",
   "repository": "linkshare/plus.garden",


### PR DESCRIPTION
If Browsermob Proxy fails to start, garden exits normally, no errors are shown.
This fix redirects errors to the console and notifies of abnormal proxy process exit.
(and incremented version number)
