### PR TITLE
Abillity to cherrypick loaders based on tags

### DIFF
--- a/app/services/FixtureLoader.js
+++ b/app/services/FixtureLoader.js
@@ -8,28 +8,35 @@
 
  var FixtureLoader = function (container, logger) {
 
-    var loaders = container.find(['garden.js', 'fixtures', 'loader']);
-
-    if (loaders.length == 0) {
-        logger.warn('fixture loader module not found');
-        logger.info('Visit https://github.com/linkshare/plus.garden/blob/master/docs/modules.md to get necessary module');
-    }
-
-    this.load = function () {
-        loaders.forEach(function (loader) {
+    this.load = function (tags) {
+        this.loaders(tags).forEach(function (loader) {
             loader.load();
         });
     }
 
-    this.drop = function () {
-        loaders.forEach(function (loader) {
+    this.drop = function (tags) {
+        this.loaders(tags).forEach(function (loader) {
             loader.drop();
         });
     }
 
-    this.reload = function () {
-        this.drop();
-        this.load();
+    this.reload = function (tags) {
+        this.drop(tags);
+        this.load(tags);
+    }
+
+    this.loaders = function(tags) {
+        var loaders = [];
+
+        tags = tags || ['garden.js', 'fixtures', 'loader'];
+        loaders = container.find(tags);
+
+        if (loaders.length == 0) {
+            logger.warn('fixture loader module not found');
+            logger.info('Visit https://github.com/linkshare/plus.garden/blob/master/docs/modules.md to get necessary module');
+        }
+
+        return loaders;
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plus.garden",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "main": "garden.js",
   "license": "MIT",
   "repository": "linkshare/plus.garden",


### PR DESCRIPTION
This enables you to do things like: 

``` javascript
this.garden.get('FixtureLoader').reload(['loader.mongo']);
```
