### PR TITLE
Escape Garden bin path

### DIFF
--- a/app/lib/Command.js
+++ b/app/lib/Command.js
@@ -6,10 +6,12 @@
  * Licensed under MIT (https://github.com/linkshare/plus.garden/blob/master/LICENSE)
  * ============================================================================== */
 
- var child_process = require('child_process');
+var child_process = require('child_process');
 var exec = child_process.exec;
 
 var Command = function (dir, env, replacement, commander) {
+
+    var utils = require('./Utils');
 
     this.replacement = replacement || {};
     this.env = env || 'test';
@@ -20,7 +22,7 @@ var Command = function (dir, env, replacement, commander) {
     }
 
     this.quote = function (name) {
-        return ('' + name).replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
+        return utils.escape(name);
     }
 
     this.prepare = function (cmd) {

--- a/app/lib/Utils.js
+++ b/app/lib/Utils.js
@@ -1,0 +1,15 @@
+/* =================================================================================
+ * @author Vladimir Polyakov
+ * @author Slava Hatnuke
+ * =================================================================================
+ * Copyright (c) 2015 Rakuten Marketing
+ * Licensed under MIT (https://github.com/linkshare/plus.garden/blob/master/LICENSE)
+ * ============================================================================== */
+
+var utils = {
+  escape: function(str) {
+    return str.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
+  }
+};
+
+module.exports = utils;

--- a/app/services/Command.js
+++ b/app/services/Command.js
@@ -7,10 +7,13 @@
 
  var Command = function (config, commander) {
 
+    var utils = require('../lib/Utils');
     var CommandClass = require('../lib/Command');
 
+    var gardenBinPath = utils.escape(config.get('garden_dir') + "/node_modules/.bin/");
+
     var replacement = {
-        "./node_modules/.bin/": config.get('garden_dir') + "/node_modules/.bin/"
+        "./node_modules/.bin/": gardenBinPath
     };
 
     this.command = new CommandClass(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plus.garden",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "main": "garden.js",
   "license": "MIT",
   "repository": "linkshare/plus.garden",


### PR DESCRIPTION
Ok to review guys? 

Basically, if you have a project folder like `(dev)publisher-dashboard-api`, Garden execution fails, as the `exec()` doesn't seem to like the bin path. In Jenkins we have a naming convention for projects now that go like `(dev-1)project-name` etc...

I moved the `quote()` function logic into a utils module, so that it can be used elsewhere. 

Lemme know.
